### PR TITLE
Use a virtual environment instead of installing the dependencies OS-wide

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,9 @@ OCF updated UPnP specification on 17.04.2020 to remediate this vulnerability. Ch
 
 ## Install
 
-    sudo python3 setup.py install
-if needed
-
-    sudo pip3 install -r requirements.txt
-cryptography
-requests
-termcolor
+    virtualenv -p python3 venv
+    source venv/bin/activate
+    pip3 install -r requirements.txt
 
 ## Usage
 


### PR DESCRIPTION
Hello,

Not sure if there's a specific reason `README` says to install the dependencies using `sudo` and thus OS-wide instead of using [virtual environments](https://virtualenv.pypa.io/en/latest/). The script seems to work properly in a virtual environment (tested on Linux and macOS) so this PR updates the `README` with instructions on how to do that.