### PR TITLE
Added Dockerfile to run CallStranger in a docker container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,9 +6,8 @@ RUN git clone https://github.com/yunuscadirci/CallStranger.git /opt/CallStranger
 
 RUN cd /opt/CallStranger && pip3 install -r requirements.txt
 
-RUN groupadd -r callstranger && useradd --no-log-init -r -g callstranger callstranger
-
-RUN chown -R callstranger:callstranger /opt/CallStranger/
+RUN groupadd -r callstranger && useradd --no-log-init -r -g callstranger callstranger \
+  && chown -R callstranger:callstranger /opt/CallStranger/
 
 USER callstranger
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-buster
+FROM python:3-buster
 
 RUN apt update && apt install git 
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,8 @@
 FROM python:3-buster
 
-RUN apt update && apt install git 
+RUN apt update \
+  && apt install git \
+  && rm -rf /var/lib/apt/lists/*
 
 RUN git clone https://github.com/yunuscadirci/CallStranger.git /opt/CallStranger
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.6-buster
+
+RUN apt update && apt install git 
+
+RUN git clone https://github.com/yunuscadirci/CallStranger.git /opt/CallStranger
+
+RUN cd /opt/CallStranger && pip3 install -r requirements.txt
+
+RUN groupadd -r callstranger && useradd --no-log-init -r -g callstranger callstranger
+
+RUN chown -R callstranger:callstranger /opt/CallStranger/
+
+USER callstranger
+
+CMD python3 /opt/CallStranger/CallStranger.py

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,15 @@
+## Docker image for Callstranger
+
+### Build the image
+Before using it, you need to build the image.
+To do so, cd into this directory and then run:
+```
+sudo docker build -t docker-callstranger:latest .
+```
+
+### Run the container
+To run the container, execute:
+```
+sudo docker run --net host --rm -ti docker-callstranger:latest
+```
+Note, you need to run this with `--net host` otherwise the UPnP packages get lost in NAT. 


### PR DESCRIPTION
Adding a Dockerfile to enable users to build a docker image for CallStranger and run it in a container.
Might be useful if one does not want to install python packages on the host. 

Only did a quick test on `x86_64` and `aarch64` and it seemed to work fine. 
